### PR TITLE
New built-in OAuth Access Token Store: iCloud Key-Value Storage

### DIFF
--- a/Heimdallr.xcodeproj/project.pbxproj
+++ b/Heimdallr.xcodeproj/project.pbxproj
@@ -129,6 +129,8 @@
 		E258A16C1CC6BC8600649F5A /* OAuthAccessTokenDefaultParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E258A1651CC6B66900649F5A /* OAuthAccessTokenDefaultParser.swift */; };
 		E258A16D1CC6BC8700649F5A /* OAuthAccessTokenDefaultParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E258A1651CC6B66900649F5A /* OAuthAccessTokenDefaultParser.swift */; };
 		E258A16E1CC6BC8800649F5A /* OAuthAccessTokenDefaultParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E258A1651CC6B66900649F5A /* OAuthAccessTokenDefaultParser.swift */; };
+		E5E39D991D04C5CE00713AC9 /* OAuthAccessTokenICloudKeyValueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E39D981D04C5CE00713AC9 /* OAuthAccessTokenICloudKeyValueStore.swift */; };
+		E5E39D9A1D04D09000713AC9 /* OAuthAccessTokenICloudKeyValueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E39D981D04C5CE00713AC9 /* OAuthAccessTokenICloudKeyValueStore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -237,6 +239,7 @@
 		DC712A5E1C85AD77009860A5 /* watchOS-StaticLibrary.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "watchOS-StaticLibrary.xcconfig"; sourceTree = "<group>"; };
 		E258A1651CC6B66900649F5A /* OAuthAccessTokenDefaultParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthAccessTokenDefaultParser.swift; sourceTree = "<group>"; };
 		E258A1671CC6B8C500649F5A /* OAuthAccessTokenParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthAccessTokenParser.swift; sourceTree = "<group>"; };
+		E5E39D981D04C5CE00713AC9 /* OAuthAccessTokenICloudKeyValueStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthAccessTokenICloudKeyValueStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -366,6 +369,7 @@
 				DC5220511BEA320B00F37F2A /* OAuthAuthorizationGrant.swift */,
 				DC5220521BEA320B00F37F2A /* OAuthClientCredentials.swift */,
 				DC5220531BEA320B00F37F2A /* OAuthError.swift */,
+				E5E39D981D04C5CE00713AC9 /* OAuthAccessTokenICloudKeyValueStore.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -892,6 +896,7 @@
 				DC5220701BEA321300F37F2A /* HeimdallrHTTPClientNSURLSession.swift in Sources */,
 				DC5220751BEA321300F37F2A /* OAuthAccessToken.swift in Sources */,
 				DC5220721BEA321300F37F2A /* HeimdallrResourceRequestAuthenticatorHTTPAuthorizationHeader.swift in Sources */,
+				E5E39D9A1D04D09000713AC9 /* OAuthAccessTokenICloudKeyValueStore.swift in Sources */,
 				DC52206F1BEA321300F37F2A /* HeimdallrHTTPClient.swift in Sources */,
 				E258A1691CC6BC7B00649F5A /* OAuthAccessTokenParser.swift in Sources */,
 				E258A16C1CC6BC8600649F5A /* OAuthAccessTokenDefaultParser.swift in Sources */,
@@ -927,6 +932,7 @@
 				DC52207D1BEA321500F37F2A /* HeimdallrHTTPClientNSURLSession.swift in Sources */,
 				DC5220821BEA321500F37F2A /* OAuthAccessToken.swift in Sources */,
 				DC52207F1BEA321500F37F2A /* HeimdallrResourceRequestAuthenticatorHTTPAuthorizationHeader.swift in Sources */,
+				E5E39D991D04C5CE00713AC9 /* OAuthAccessTokenICloudKeyValueStore.swift in Sources */,
 				E258A1681CC6B8C500649F5A /* OAuthAccessTokenParser.swift in Sources */,
 				DC52207C1BEA321500F37F2A /* HeimdallrHTTPClient.swift in Sources */,
 				E258A1661CC6B66900649F5A /* OAuthAccessTokenDefaultParser.swift in Sources */,

--- a/Heimdallr/Core/OAuthAccessTokenICloudKeyValueStore.swift
+++ b/Heimdallr/Core/OAuthAccessTokenICloudKeyValueStore.swift
@@ -1,0 +1,63 @@
+//
+//  OAuthAccessTokenICloudKeyValueStore.swift
+//  Heimdallr
+//
+//  Created by Fabio Milano on 05/06/16.
+//  Copyright © 2016 B264 GmbH. All rights reserved.
+//
+
+import Foundation
+
+/// A persistent iCloud Key Value based access token store.
+@objc public class OAuthAccessTokenICloudKeyValueStore: NSObject, OAuthAccessTokenStore {
+    private let store = NSUbiquitousKeyValueStore.defaultStore()
+    private let service: String
+    
+    public init(service: String = "de.rheinfabrik.heimdallr.oauth") {
+        self.service = service
+    }
+    
+    public func storeAccessToken(accessToken: OAuthAccessToken?) {
+        if let accessToken = accessToken {
+            var accessTokenDictionaryRepresentation = [String: String]()
+    
+            accessTokenDictionaryRepresentation.updateValue(accessToken.accessToken, forKey: "access_token")
+            accessTokenDictionaryRepresentation.updateValue(accessToken.tokenType, forKey: "token_type")
+            
+            if let refreshToken = accessToken.refreshToken {
+                accessTokenDictionaryRepresentation.updateValue(refreshToken, forKey: "refresh_token")
+            }
+            
+            accessTokenDictionaryRepresentation.updateValue(accessToken.accessToken, forKey: "access_token")
+        
+            if let expiresAt = accessToken.expiresAt {
+                accessTokenDictionaryRepresentation.updateValue(expiresAt.timeIntervalSince1970.description, forKey: "expires_at")
+            }
+            
+            store.setDictionary(accessTokenDictionaryRepresentation, forKey: service)
+        }
+        
+        store.synchronize()
+    }
+    
+    public func retrieveAccessToken() -> OAuthAccessToken? {
+        if let accessTokenDictionaryRepresentation = store.dictionaryForKey(service) {
+            let accessToken = accessTokenDictionaryRepresentation["access_token"] as? String
+            let tokenType = accessTokenDictionaryRepresentation["token_type"] as? String
+            let refreshToken = accessTokenDictionaryRepresentation["refresh_token"] as? String
+            let expiresAtString = accessTokenDictionaryRepresentation["expires_at"] as? String
+                
+            let expiresAt = expiresAtString.flatMap { description in
+                return Double(description).flatMap { expiresAtInSeconds in
+                    return NSDate(timeIntervalSince1970: expiresAtInSeconds)
+                }
+            }
+            
+            if let accessToken = accessToken, tokenType = tokenType {
+                return OAuthAccessToken(accessToken: accessToken, tokenType: tokenType, expiresAt: expiresAt, refreshToken: refreshToken)
+            }
+        }
+        
+        return nil
+    }
+}

--- a/Heimdallr/Core/OAuthAccessTokenICloudKeyValueStore.swift
+++ b/Heimdallr/Core/OAuthAccessTokenICloudKeyValueStore.swift
@@ -37,10 +37,12 @@ import Foundation
             store.setDictionary(accessTokenDictionaryRepresentation, forKey: service)
         }
         
-        store.synchronize()
+        synchronize()
     }
     
     public func retrieveAccessToken() -> OAuthAccessToken? {
+        synchronize()
+        
         if let accessTokenDictionaryRepresentation = store.dictionaryForKey(service) {
             let accessToken = accessTokenDictionaryRepresentation["access_token"] as? String
             let tokenType = accessTokenDictionaryRepresentation["token_type"] as? String
@@ -59,5 +61,22 @@ import Foundation
         }
         
         return nil
+    }
+    
+    private func synchronize() -> Void {
+        #if DEBUG
+            let synchronized = store.synchronize()
+            
+            let userInfo = [
+                NSLocalizedDescriptionKey: NSLocalizedString("Could not initialize an iCloud Key Value Store", comment: ""),
+                NSLocalizedFailureReasonErrorKey: NSLocalizedString("Something went wrong in initializing an iCloud Key Value Store.", comment: "")
+            ]
+            
+            if !synchronized {
+                NSException(name: "OAuthAccessTokenICloudKeyValueStore", reason: NSLocalizedString("Make sure the app has registered to proper iCloud capabilities.", comment: ""), userInfo: userInfo).raise()
+            }
+        #else
+            store.synchronize()
+        #endif
     }
 }

--- a/README.md
+++ b/README.md
@@ -107,13 +107,24 @@ protocol OAuthAccessTokenStore {
 }
 ```
 
-Heimdallr ships with an already built-in persistent keychain-based access token store. The service is configurable:
+Heimdallr ships with two already built-in persistent access token store. 
+
+
+#### Keychain-based access token store
+
+The service is configurable:
 
 ```swift
 var service: String!
 
 let accessTokenStore = OAuthAccessTokenKeychainStore(service: service)
 ```
+
+#### iCloud Key Value-based access token store
+
+It stores values on the iCloud Key-Value Storage container for the current iCloud account.
+
+Before using this persistent access token store, please make sure your are app has been properly setup for __iCloud Key-Value Storage__ capability. More info [here](https://developer.apple.com/library/mac/documentation/IDEs/Conceptual/AppDistributionGuide/AddingCapabilities/AddingCapabilities.html#//apple_ref/doc/uid/TP40012582-CH26-SW19).
 
 ### HeimdallrHTTPClient
 


### PR DESCRIPTION
# Summary

Added a new OAuth Access Token Store base on iCloud Key-Value Storage.

# Why

I wanted to have the opportunity to store access token information in a shared container accessible from other devices that do not have capabilities to support the OAuth 2 authentication process (like tvOS). By using this new built in store, the user can rely on the iCloud Key-Value Storage, connected to his personal iCloud account, to share authentication information retreived from other devices.

# Notes

1) I'm not sure how to write tests for this feature. The new class I created his heavily coupled with a valid iCloud Key-Value Storage. Any idea?

2) It would be nice to improve the `OAuthAccessTokenStore` protocol with a proper callback method that notifies when a new access token has been set. Currently, if new information have been sent from another device, the user has to manually query the iCloud Key-Value Store again to retrieve new information.